### PR TITLE
small usability improvement

### DIFF
--- a/cmd/ovs-flowmon/main.go
+++ b/cmd/ovs-flowmon/main.go
@@ -228,7 +228,7 @@ func mainPage(pages *tview.Pages) {
 		})
 	}
 
-	menuList.AddItem("Start", "", 's', start)
+	menuList.AddItem("Start", "", 'S', start)
 	if *ovsdb != "" {
 		menuList.AddItem("Config", "", 'c', config)
 	}


### PR DESCRIPTION
changing "start" rune to "S" as "s" was overloaded and "sort" is used more often than "start".